### PR TITLE
Revert "chore: time steps (#8)"

### DIFF
--- a/time_grid.go
+++ b/time_grid.go
@@ -4,20 +4,6 @@ import "golang.org/x/exp/slices"
 
 type TimeGrid []float64
 
-func (g TimeGrid) Steps() []float64 {
-	n := len(g)
-	if n < 2 {
-		return nil
-	}
-
-	dts := make([]float64, n-1)
-	for i, t := range g[:n-1] {
-		dts[i] = g[i+1] - t
-	}
-
-	return dts
-}
-
 func NewTimeGrid(ts ...float64) TimeGrid {
 	slices.Sort(ts)
 

--- a/time_grid_test.go
+++ b/time_grid_test.go
@@ -41,39 +41,3 @@ func Test_NewTimeGrid(t *testing.T) {
 		})
 	}
 }
-
-func Test_TimeGrid_Steps(t *testing.T) {
-	t.Parallel()
-
-	const tol = 1.0e-15
-
-	for _, tc := range []struct {
-		name     string
-		grid     TimeGrid
-		expected []float64
-	}{
-		{
-			"empty",
-			NewTimeGrid(),
-			nil,
-		},
-		{
-			"one point",
-			NewTimeGrid(1.0),
-			nil,
-		},
-		{
-			"uniform",
-			NewUniformTimeGrid(0.0, 1.0, 5),
-			[]float64{0.2, 0.2, 0.2, 0.2, 0.2},
-		},
-	} {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.InDeltaSlice(t, tc.expected, tc.grid.Steps(), tol)
-		})
-	}
-}


### PR DESCRIPTION
This reverts commit 5dbf21791620bb77189b6aadfed8160d068d2ed4.

Time steps can be leveraged by a time-invariant process along the discretization, but aren't general enough for any stochastic process. It should be up to the process itself to infer the $\Delta T$ between two time inputs.